### PR TITLE
KeyGen: indifferentiability for HKDF

### DIFF
--- a/draft-irtf-cfrg-bls-signature.md
+++ b/draft-irtf-cfrg-bls-signature.md
@@ -602,12 +602,13 @@ Parameters:
 Definitions:
 - HKDF-Extract is as defined in RFC5869, instantiated with hash H.
 - HKDF-Expand is as defined in RFC5869, instantiated with hash H.
+- I2OSP and OS2IP are as defined in RFC8017, Section 4.
 - L is the integer given by ceil((3 * ceil(log2(r))) / 16).
 - "BLS-SIG-KEYGEN-SALT-" is an ASCII string comprising 20 octets.
 
 Procedure:
-1. PRK = HKDF-Extract("BLS-SIG-KEYGEN-SALT-", IKM)
-2. OKM = HKDF-Expand(PRK, key_info, L)
+1. PRK = HKDF-Extract("BLS-SIG-KEYGEN-SALT-", IKM || I2OSP(0, 1))
+2. OKM = HKDF-Expand(PRK, key_info || I2OSP(L, 2), L)
 3. SK = OS2IP(OKM) mod r
 4. return SK
 ~~~


### PR DESCRIPTION
We can prove indifferentiability for HKDF just if we can be sure
that IKM ends with an octet that's different from the final octet
of the input to any invocation of HMAC inside of HKDF-Expand.
Fortunately, HKDF-Expand's counter starts at 1 and is appended
to the input to HMAC---so we can get indifferentiability just
by appending a 0 octet to IKM.

This is more of a safety / paranoia thing than anything else.

Also, the prior commit added key_info to optionally orthogonalize
different invocations of KeyGen called on the same key. In this
commit, I also appended a two-byte encoding of L to the info field.
This means that using the same keying material to extract different
lengths of key will give different results, which seems nice.